### PR TITLE
:boom: Migrate to Forge API v2 (org/server-scoped, new required input)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ For example, a `fix-37` branch with `mydomain.tld` root_domain will result in a 
 
 `database_name` is also based on the branch name (escaping it with only `a-z0-9_` chars).
 
+## Upgrading to v2
+
+Starting with `v2`, this action uses [Forge API v2](https://forge.laravel.com/docs/api-reference/introduction), which is organized around organizations and servers instead of a flat list of servers as in v1. This is a breaking change if you are currently using `@v1` (or a `v1.x` tag).
+
+### What you need to change in your workflow
+
+1. **Pin the action to `@v2`** instead of `@v1` (or a `v1.x` tag). `@v1` keeps working against the previous behavior for existing consumers, it will not receive the v2 changes.
+2. **Add the new required input `forge_organization`**, set to the slug of the organization that owns your server (visible in the Forge dashboard URL when browsing your server).
+3. Regenerate/verify your `forge_api_token` still has access to the organization and server you are targeting.
+
+Everything else (inputs, outputs, host/database name generation) keeps working the same way.
+
 ## Inputs
 
 It is highly recommended that you store all inputs using [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) or variables.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It works in combination with this other action which removes create ad setup rev
 
 ### Action running process
 
-All steps are done using [Forge API](https://forge.laravel.com/api-documentation).
+All steps are done using the [Forge API v2](https://forge.laravel.com/docs/api-reference/introduction).
 
 - Delete site.
 - Delete database.
@@ -33,6 +33,7 @@ It is highly recommended that you store all inputs using [GitHub Secrets](https:
 | Input                   | Required | Default | Description                                                                                                                                                                                   |
 |-------------------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `forge_api_token`       | yes      |         | Laravel Forge API key.<br>You can generate an API key in your [Forge dashboard](https://forge.laravel.com/user-profile/api).                                                                  |
+| `forge_organization`    | yes      |         | Laravel Forge organization slug (required by the [API v2](https://forge.laravel.com/docs/api-reference/introduction)).                                                                       |
 | `forge_server_id`       | yes      |         | Laravel Forge server ID                                                                                                                                                                       |
 | `root_domain`           | no       |         | Root domain under which to create review-app site.                                                                                                                                            |
 | `host`                  | no       |         | Site host of the review-app.<br>The branch name the action is running on will be used to generate it if not defined (recommended).                                                            |
@@ -66,9 +67,10 @@ jobs:
 
     steps:
       - name: Clean review-app on Forge
-        uses: web-id-fr/forge-review-app-clean-action@v1.0.0
+        uses: web-id-fr/forge-review-app-clean-action@v2.0.0
         with:
           forge_api_token: ${{ secrets.FORGE_API_TOKEN }}
+          forge_organization: ${{ secrets.FORGE_ORGANIZATION }}
           forge_server_id: ${{ secrets.FORGE_SERVER_ID }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
   steps:
     - name: "Forge Review-app Clean Action"
       id: forge-review-app-clean-action
-      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:forge-api-v2-migration"
+      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v2.0.0"
       env:
         INPUT_FORGE_API_TOKEN: ${{ inputs.forge_api_token }}
         INPUT_FORGE_ORGANIZATION: ${{ inputs.forge_organization }}

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   forge_api_token:
     description: 'Laravel Forge API key'
     required: true
+  forge_organization:
+    description: 'Laravel Forge organization slug'
+    required: true
   forge_server_id:
     description: 'Laravel Forge server ID'
     required: true
@@ -48,9 +51,10 @@ runs:
   steps:
     - name: "Forge Review-app Clean Action"
       id: forge-review-app-clean-action
-      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v1.1.2"
+      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v2.0.0"
       env:
         INPUT_FORGE_API_TOKEN: ${{ inputs.forge_api_token }}
+        INPUT_FORGE_ORGANIZATION: ${{ inputs.forge_organization }}
         INPUT_FORGE_SERVER_ID: ${{ inputs.forge_server_id }}
         INPUT_ROOT_DOMAIN: ${{ inputs.root_domain }}
         INPUT_HOST: ${{ inputs.host }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
   steps:
     - name: "Forge Review-app Clean Action"
       id: forge-review-app-clean-action
-      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v2.0.0"
+      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:forge-api-v2-migration"
       env:
         INPUT_FORGE_API_TOKEN: ${{ inputs.forge_api_token }}
         INPUT_FORGE_ORGANIZATION: ${{ inputs.forge_organization }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,18 +99,21 @@ if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
 fi
 
 AUTH_HEADER="Authorization: Bearer $INPUT_FORGE_API_TOKEN"
+ACCEPT_HEADER="Accept: application/vnd.api+json"
+
+API_BASE="https://forge.laravel.com/api/orgs/$INPUT_FORGE_ORGANIZATION/servers/$INPUT_FORGE_SERVER_ID"
 
 echo '* Get Forge server sites'
-API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/sites"
+API_URL="$API_BASE/sites?filter%5Bname%5D=$INPUT_HOST"
 JSON_RESPONSE=$(
   curl -s -H "$AUTH_HEADER" \
-    -H "Accept: application/json" \
+    -H "$ACCEPT_HEADER" \
     "$API_URL"
 )
 echo "$JSON_RESPONSE" > sites.json
 
-# Check if review-app site exists
-SITE_DATA=$(jq -r '.sites[] | select(.name == "'"$INPUT_HOST"'") // empty' sites.json)
+# Check if review-app site exists (filter[name] may be a partial match, so confirm the exact name)
+SITE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$INPUT_HOST"'") // empty' sites.json)
 if [[ ! -z "$SITE_DATA" ]]; then
   echo "$SITE_DATA" > site.json
   SITE_ID=$(jq -r '.id' site.json)
@@ -125,21 +128,19 @@ if [[ $RA_FOUND == 'true' ]]; then
   echo ""
   echo "* Delete review-app site"
 
-  API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/sites/$SITE_ID"
+  API_URL="$API_BASE/sites/$SITE_ID"
 
   HTTP_STATUS=$(
     curl -s -o response.json -w "%{http_code}" \
       -X DELETE \
       -H "$AUTH_HEADER" \
-      -H "Accept: application/json" \
-      -H "Content-Type: application/json" \
-      -d "$JSON_PAYLOAD" \
+      -H "$ACCEPT_HEADER" \
       "$API_URL"
   )
 
   JSON_RESPONSE=$(cat response.json)
 
-  if [[ $HTTP_STATUS -eq 200 ]]; then
+  if [[ $HTTP_STATUS -eq 202 ]]; then
     echo "Site (ID $SITE_ID) deleted successfully"
   else
     echo "Failed to delete site (ID $SITE_ID). HTTP status code: $HTTP_STATUS"
@@ -151,16 +152,16 @@ fi
 
 echo ""
 echo '* Get Forge server databases'
-API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/databases"
+API_URL="$API_BASE/database/schemas?filter%5Bname%5D=$INPUT_DATABASE_NAME"
 JSON_RESPONSE=$(
   curl -s -H "$AUTH_HEADER" \
-    -H "Accept: application/json" \
+    -H "$ACCEPT_HEADER" \
     "$API_URL"
 )
 echo "$JSON_RESPONSE" > databases.json
 
-# Check if review-app database exists
-DATABASE_DATA=$(jq -r '.databases[] | select(.name == "'"$INPUT_DATABASE_NAME"'") // empty' databases.json)
+# Check if review-app database exists (filter[name] may be a partial match, so confirm the exact name)
+DATABASE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$INPUT_DATABASE_NAME"'") // empty' databases.json)
 if [[ ! -z "$DATABASE_DATA" ]]; then
   echo "$DATABASE_DATA" > database.json
   DATABASE_ID=$(jq -r '.id' database.json)
@@ -175,26 +176,22 @@ if [[ $DATABASE_FOUND == 'true' ]]; then
   echo ""
   echo "* Delete review-app database"
 
-  API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/databases/$DATABASE_ID"
+  API_URL="$API_BASE/database/schemas/$DATABASE_ID"
 
   HTTP_STATUS=$(
     curl -s -o response.json -w "%{http_code}" \
       -X DELETE \
       -H "$AUTH_HEADER" \
-      -H "Accept: application/json" \
-      -H "Content-Type: application/json" \
-      -d "$JSON_PAYLOAD" \
+      -H "$ACCEPT_HEADER" \
       "$API_URL"
   )
 
   JSON_RESPONSE=$(cat response.json)
 
-  if [[ $HTTP_STATUS -eq 200 ]]; then
-    echo $(jq '.site' response.json) > site.json
-    SITE_ID=$(jq -r '.id' site.json)
+  if [[ $HTTP_STATUS -eq 202 ]]; then
     echo "Database (ID $DATABASE_ID, NAME $INPUT_DATABASE_NAME) deleted successfully"
   else
-    echo "Failed to delete database (ID $SITE_ID, NAME $INPUT_DATABASE_NAME). HTTP status code: $HTTP_STATUS"
+    echo "Failed to delete database (ID $DATABASE_ID, NAME $INPUT_DATABASE_NAME). HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
     exit 1


### PR DESCRIPTION
Migration vers l'API v2 de Forge (organisation/serveur), suite à la dépréciation de l'API v1 (arrêt prévu le 31 juillet 2026).

- `API_BASE` scopé par organisation/serveur
- Recherche de site/base de données via `filter[name]=`
- Suppression via code retour `202` (au lieu de `200`)
- Nouvel input requis `forge_organization`