### PR TITLE
Add opt-in orphan cleanup mode for stale review-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,58 @@ It is highly recommended that you store all inputs using [GitHub Secrets](https:
 | `pr_number`             | no       |         | Manually define pull-request number (⚠️ Based on `GITHUB_REF_NAME` by default, but does not seems to work properly, according to this [issue](https://github.com/actions/runner/issues/256)). |
 | `database_name`         | no       |         | Database name of the review-app site.<br>The branch name the action is running on will be used to generate it if not defined (recommended).                                                   |
 | `database_name_prefix`  | no       |         | Database name prefix, useful for PostgreSQL that does not support digits (PR number) for first chars.                                                                                         |
+| `cleanup_orphans`       | no       | `false` | Enable "orphan cleanup" mode (see below): instead of deleting a single, precisely-identified review-app, discover and delete every review-app on the server whose PR is no longer open.        |
+| `repository`            | no (required if `cleanup_orphans: true`) | `$GITHUB_REPOSITORY` | GitHub repository (`owner/repo`) to check PR state against.                                                                                                            |
+| `github_token`          | no (required if `cleanup_orphans: true`) |  | GitHub token used to check PR state (`repos/{repository}/pulls/{pr}`). Read access to pull requests is enough.                                                                       |
+| `host_pattern`          | no       | derived from `root_domain`: `^[0-9]+-.*\.{root_domain}$` | ERE regex (`jq`/`grep -P` compatible) used to identify review-app sites among all sites on the server. Override if your naming scheme differs from `{pr}-{branch}.{root_domain}`. |
+| `dry_run`               | no       | `false` | If `true` (in `cleanup_orphans` mode), only log the orphaned sites that would be deleted, without deleting anything. Useful for a first verification run.                                     |
 
 ## Outputs
 
-| Output          | Description                                                          |
-|-----------------|----------------------------------------------------------------------|
-| `host`          | Host of the review-app (generated or forced one in inputs).          |
-| `database_name` | Database name of the review-app (generated or forced one in inputs). |
+| Output            | Description                                                                                                      |
+|-------------------|--------------------------------------------------------------------------------------------------------------------|
+| `host`            | Host of the review-app (generated or forced one in inputs). Empty in `cleanup_orphans` mode.                     |
+| `database_name`   | Database name of the review-app (generated or forced one in inputs). Empty in `cleanup_orphans` mode.            |
+| `orphans_found`   | Number of orphaned review-apps detected (`cleanup_orphans` mode only).                                           |
+| `orphans_deleted` | Number of orphaned review-apps actually deleted (`cleanup_orphans` mode only, always `0` if `dry_run: true`).    |
+| `orphans_json`    | JSON array of the orphaned sites processed, e.g. `[{"pr": "1234", "host": "1234-fix-bug.example.com", "deleted": true}]` (`cleanup_orphans` mode only). |
+
+## Orphan cleanup mode
+
+The default mode (documented above) deletes **one** review-app, reacting to a single PR event (`closed`, `unlabeled`). If that triggering event is ever missed (cancelled run, disabled workflow, label removed then PR closed outside GitHub Actions...), the review-app is left orphaned on the Forge server forever, since nothing re-triggers the missed event.
+
+`cleanup_orphans: true` switches the action to a periodic, self-healing mode instead: it lists every site on the Forge server, filters the ones that look like review-apps (`host_pattern`), checks the state of their associated PR via the GitHub API, and deletes the ones whose PR is no longer open (closed, merged, or deleted).
+
+To stay safe by default: a site is only ever deleted when the PR's state is confirmed as not open. If the GitHub API call fails or is rate-limited, the site is **skipped** (not deleted) — it will simply be re-checked on the next scheduled run.
+
+This is entirely opt-in and additive: when `cleanup_orphans` is absent or `false`, the action behaves exactly as before, with the same inputs/outputs.
+
+Typical usage, on a schedule:
+
+```yml
+name: review-app-force-clean
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup-orphans:
+    runs-on: ubuntu-latest
+    name: "Clean orphaned Forge review-apps"
+
+    steps:
+      - name: Clean orphaned review-apps on Forge
+        uses: web-id-fr/forge-review-app-clean-action@v2
+        with:
+          cleanup_orphans: 'true'
+          forge_api_token: ${{ secrets.FORGE_API_TOKEN }}
+          forge_organization: ${{ secrets.FORGE_ORGANIZATION }}
+          forge_server_id: ${{ secrets.FORGE_SERVER_ID }}
+          root_domain: myapp.example.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: 'false'
+```
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -37,21 +37,47 @@ inputs:
     required: false
   database_name_prefix:
     description: 'Database name prefix, useful for PostgreSQL that does not support digits (PR number) for first chars'
+  cleanup_orphans:
+    description: 'Enable "orphan cleanup" mode: ignore host/pr_number/database_name and discover+delete orphaned review-apps on the server'
+    required: false
+    default: 'false'
+  repository:
+    description: 'GitHub repository ("owner/repo") to check PR state against. Required if cleanup_orphans is true. Defaults to GITHUB_REPOSITORY'
+    required: false
+  github_token:
+    description: 'GitHub token used to check PR state (repos/{repository}/pulls/{pr}). Required if cleanup_orphans is true'
+    required: false
+  host_pattern:
+    description: 'ERE regex (jq/grep -P compatible) used to identify review-app sites among all server sites. Defaults to a pattern derived from root_domain'
+    required: false
+  dry_run:
+    description: 'If true, only log the orphans that would be deleted, without deleting anything'
+    required: false
+    default: 'false'
 
 outputs:
   host:
-    description: 'Host of the review-app (generated or forced one in inputs)'
+    description: 'Host of the review-app (generated or forced one in inputs). Not used in cleanup_orphans mode'
     value: ${{ steps.forge-review-app-clean-action.outputs.host }}
   database_name:
-    description: 'Database name of the review-app (generated or forced one in inputs)'
+    description: 'Database name of the review-app (generated or forced one in inputs). Not used in cleanup_orphans mode'
     value: ${{ steps.forge-review-app-clean-action.outputs.database_name }}
+  orphans_found:
+    description: 'Number of orphaned review-apps detected (cleanup_orphans mode only)'
+    value: ${{ steps.forge-review-app-clean-action.outputs.orphans_found }}
+  orphans_deleted:
+    description: 'Number of orphaned review-apps actually deleted (cleanup_orphans mode only, 0 if dry_run)'
+    value: ${{ steps.forge-review-app-clean-action.outputs.orphans_deleted }}
+  orphans_json:
+    description: 'JSON array of the orphaned sites processed (cleanup_orphans mode only)'
+    value: ${{ steps.forge-review-app-clean-action.outputs.orphans_json }}
 
 runs:
   using: 'composite'
   steps:
     - name: "Forge Review-app Clean Action"
       id: forge-review-app-clean-action
-      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v2.0.0"
+      uses: "docker://ghcr.io/web-id-fr/forge-review-app-clean-action:v2.1.0"
       env:
         INPUT_FORGE_API_TOKEN: ${{ inputs.forge_api_token }}
         INPUT_FORGE_ORGANIZATION: ${{ inputs.forge_organization }}
@@ -63,3 +89,9 @@ runs:
         INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         INPUT_DATABASE_NAME: ${{ inputs.database_name }}
         INPUT_DATABASE_NAME_PREFIX: ${{ inputs.database_name_prefix }}
+        INPUT_CLEANUP_ORPHANS: ${{ inputs.cleanup_orphans }}
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_HOST_PATTERN: ${{ inputs.host_pattern }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        GITHUB_REPOSITORY: ${{ github.repository }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 AUTH_HEADER="Authorization: Bearer $INPUT_FORGE_API_TOKEN"
@@ -6,9 +6,12 @@ ACCEPT_HEADER="Accept: application/vnd.api+json"
 API_BASE="https://forge.laravel.com/api/orgs/$INPUT_FORGE_ORGANIZATION/servers/$INPUT_FORGE_SERVER_ID"
 
 # Delete a Forge site by exact host name, if it exists.
-# Sets SITE_DELETED to 'true'/'false'.
+# Sets SITE_STATUS to 'deleted' / 'not_found' / 'error' (does not exit on API
+# failure: callers decide whether that's fatal, see run_classic_mode vs
+# run_cleanup_orphans_mode).
 delete_site() {
-  HOST="$1"
+  local HOST="$1"
+  local API_URL JSON_RESPONSE SITE_DATA SITE_ID HTTP_STATUS
 
   API_URL="$API_BASE/sites?filter%5Bname%5D=$HOST"
   JSON_RESPONSE=$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" "$API_URL")
@@ -18,7 +21,7 @@ delete_site() {
   SITE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$HOST"'") // empty' sites.json)
   if [[ -z "$SITE_DATA" ]]; then
     echo "Site $HOST not found"
-    SITE_DELETED='false'
+    SITE_STATUS='not_found'
     return
   fi
 
@@ -41,19 +44,21 @@ delete_site() {
 
   if [[ $HTTP_STATUS -eq 202 ]]; then
     echo "Site (ID $SITE_ID) deleted successfully"
-    SITE_DELETED='true'
+    SITE_STATUS='deleted'
   else
     echo "Failed to delete site (ID $SITE_ID). HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
-    exit 1
+    SITE_STATUS='error'
   fi
 }
 
 # Delete a Forge database schema by exact name, if it exists.
-# Sets DATABASE_DELETED to 'true'/'false'.
+# Sets DATABASE_STATUS to 'deleted' / 'not_found' / 'error' (does not exit on
+# API failure: callers decide whether that's fatal).
 delete_database() {
-  DB_NAME="$1"
+  local DB_NAME="$1"
+  local API_URL JSON_RESPONSE DATABASE_DATA DATABASE_ID HTTP_STATUS
 
   echo ""
   echo '* Get Forge server databases'
@@ -65,7 +70,7 @@ delete_database() {
   DATABASE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$DB_NAME"'") // empty' databases.json)
   if [[ -z "$DATABASE_DATA" ]]; then
     echo "Database $DB_NAME not found"
-    DATABASE_DELETED='false'
+    DATABASE_STATUS='not_found'
     return
   fi
 
@@ -88,12 +93,12 @@ delete_database() {
 
   if [[ $HTTP_STATUS -eq 202 ]]; then
     echo "Database (ID $DATABASE_ID, NAME $DB_NAME) deleted successfully"
-    DATABASE_DELETED='true'
+    DATABASE_STATUS='deleted'
   else
     echo "Failed to delete database (ID $DATABASE_ID, NAME $DB_NAME). HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
-    exit 1
+    DATABASE_STATUS='error'
   fi
 }
 
@@ -197,9 +202,15 @@ run_classic_mode() {
 
   echo '* Get Forge server sites'
   delete_site "$INPUT_HOST"
+  if [[ "$SITE_STATUS" == 'error' ]]; then
+    exit 1
+  fi
 
   echo ""
   delete_database "$INPUT_DATABASE_NAME"
+  if [[ "$DATABASE_STATUS" == 'error' ]]; then
+    exit 1
+  fi
 }
 
 # List every site on the Forge server, following JSON:API pagination (links.next).
@@ -224,7 +235,8 @@ list_all_sites() {
 # NB: this does not account for a custom fqdn_prefix, which is not
 # recoverable from the host alone.
 derive_database_name_from_host() {
-  HOST="$1"
+  local HOST="$1"
+  local SEGMENT DB_NAME
   SEGMENT="$HOST"
   if [[ -n "$INPUT_ROOT_DOMAIN" && "$HOST" == *".$INPUT_ROOT_DOMAIN" ]]; then
     SEGMENT="${HOST%.$INPUT_ROOT_DOMAIN}"
@@ -239,7 +251,8 @@ derive_database_name_from_host() {
 # Check the state of a GitHub PR.
 # Echoes one of: open | closed | not_found | unknown (API error/rate-limit: treat as "don't touch").
 check_pr_state() {
-  PR_NUMBER="$1"
+  local PR_NUMBER="$1"
+  local GH_URL HTTP_STATUS STATE
 
   GH_URL="https://api.github.com/repos/$EFFECTIVE_REPOSITORY/pulls/$PR_NUMBER"
   HTTP_STATUS=$(
@@ -304,13 +317,25 @@ run_cleanup_orphans_mode() {
     [.[] | select(.attributes.name | test($pat))
          | {id: .id, host: .attributes.name}]
   ' all_sites.json > matched_sites.json
+  MATCHED_COUNT=$(jq 'length' matched_sites.json)
 
-  # Extract the PR number (leading digits) from each matched host, drop
-  # non-matching entries, then dedup by PR number (keep first occurrence).
+  # A matched host may still not start with a PR number, e.g. with a custom
+  # host_pattern that does not anchor on it. Such sites can never be resolved
+  # to a PR, so make that visible instead of silently dropping them.
+  jq '[.[] | select(.host | test("^[0-9]+-") | not)]' matched_sites.json > unparsable_sites.json
+  UNPARSABLE_COUNT=$(jq 'length' unparsable_sites.json)
+  if [[ $UNPARSABLE_COUNT -gt 0 ]]; then
+    echo "Warning: $UNPARSABLE_COUNT of $MATCHED_COUNT matched site(s) do not start with a PR number ({pr}-...) and will be ignored (they can never be cleaned up by this action):"
+    jq -r '.[].host' unparsable_sites.json | sed 's/^/  - /'
+  fi
+
+  # Extract the PR number (leading digits) from each parsable host, then
+  # dedup by PR number (keep first occurrence).
+  jq '[.[] | select(.host | test("^[0-9]+-"))]' matched_sites.json > parsable_sites.json
   jq '
-    [.[] | (.host | capture("^(?<pr>[0-9]+)-").pr) as $pr | . + {pr: $pr}]
+    [.[] | . + {pr: (.host | capture("^(?<pr>[0-9]+)-").pr)}]
     | unique_by(.pr)
-  ' matched_sites.json > candidates.json
+  ' parsable_sites.json > candidates.json
 
   CANDIDATE_COUNT=$(jq 'length' candidates.json)
   echo "Found $CANDIDATE_COUNT candidate review-app(s) after filtering/dedup"
@@ -319,9 +344,14 @@ run_cleanup_orphans_mode() {
   ORPHANS_DELETED=0
   echo '[]' > orphans.json
 
-  for i in $(seq 0 $((CANDIDATE_COUNT - 1))); do
-    [[ $CANDIDATE_COUNT -eq 0 ]] && break
+  append_orphan_result() {
+    local PR="$1" HOST="$2" DELETED="$3"
+    jq --arg pr "$PR" --arg host "$HOST" --argjson deleted "$DELETED" \
+      '. + [{pr: $pr, host: $host, deleted: $deleted}]' orphans.json > orphans.json.tmp
+    mv orphans.json.tmp orphans.json
+  }
 
+  for i in $(seq 0 $((CANDIDATE_COUNT - 1))); do
     CANDIDATE=$(jq -c ".[$i]" candidates.json)
     CANDIDATE_PR=$(echo "$CANDIDATE" | jq -r '.pr')
     CANDIDATE_HOST=$(echo "$CANDIDATE" | jq -r '.host')
@@ -343,21 +373,30 @@ run_cleanup_orphans_mode() {
     # PR_STATE is "closed" or "not_found": confirmed orphan
     echo "PR #$CANDIDATE_PR is $PR_STATE, site $CANDIDATE_HOST is orphaned"
     ORPHANS_FOUND=$((ORPHANS_FOUND + 1))
-    DELETED='false'
 
     if [[ "${INPUT_DRY_RUN:-false}" == 'true' ]]; then
       echo "[dry_run] Would delete site $CANDIDATE_HOST (and its database)"
-    else
-      delete_site "$CANDIDATE_HOST"
-      DB_NAME=$(derive_database_name_from_host "$CANDIDATE_HOST")
-      delete_database "$DB_NAME"
-      DELETED='true'
-      ORPHANS_DELETED=$((ORPHANS_DELETED + 1))
+      append_orphan_result "$CANDIDATE_PR" "$CANDIDATE_HOST" 'false'
+      continue
     fi
 
-    jq --arg pr "$CANDIDATE_PR" --arg host "$CANDIDATE_HOST" --argjson deleted "$DELETED" \
-      '. + [{pr: $pr, host: $host, deleted: $deleted}]' orphans.json > orphans.json.tmp
-    mv orphans.json.tmp orphans.json
+    delete_site "$CANDIDATE_HOST"
+    if [[ "$SITE_STATUS" == 'error' ]]; then
+      echo "Warning: failed to delete site $CANDIDATE_HOST, skipping this candidate for now (it will be retried on the next run)"
+      append_orphan_result "$CANDIDATE_PR" "$CANDIDATE_HOST" 'false'
+      continue
+    fi
+
+    DB_NAME=$(derive_database_name_from_host "$CANDIDATE_HOST")
+    delete_database "$DB_NAME"
+    if [[ "$DATABASE_STATUS" == 'error' ]]; then
+      echo "Warning: site $CANDIDATE_HOST was deleted but failed to delete database $DB_NAME, skipping the rest of this candidate for now (it will be retried on the next run)"
+      append_orphan_result "$CANDIDATE_PR" "$CANDIDATE_HOST" 'false'
+      continue
+    fi
+
+    ORPHANS_DELETED=$((ORPHANS_DELETED + 1))
+    append_orphan_result "$CANDIDATE_PR" "$CANDIDATE_HOST" 'true'
   done
 
   echo ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,135 +1,35 @@
 #!/bin/sh
 set -e
 
-# Prepare vars and default values
-
-if [[ -z "$INPUT_BRANCH" ]]; then
-  INPUT_BRANCH=$GITHUB_HEAD_REF
-fi
-
-ESCAPED_BRANCH=$(echo "$INPUT_BRANCH" | sed -e 's/[^a-z0-9-]/-/g' | tr -s '-')
-
-# Remove the trailing "-" character
-if [[ $ESCAPED_BRANCH == *- ]]; then
-    ESCAPED_BRANCH="${ESCAPED_BRANCH%-}"
-fi
-
-if [[ -z "$INPUT_PREFIX_WITH_PR_NUMBER" ]]; then
-  INPUT_PREFIX_WITH_PR_NUMBER='true'
-fi
-
-if [[ $INPUT_PREFIX_WITH_PR_NUMBER == 'true' ]]; then
-  if [[ -z "$INPUT_PR_NUMBER" ]]; then
-    echo "* PR_NUMBER extraction from GITHUB_REF_NAME value: $GITHUB_REF_NAME"
-    set +e
-    PR_NUMBER=$(echo "$GITHUB_REF_NAME" | grep -oE '[0-9]+')
-    set -e
-    if [[ -z "$PR_NUMBER" ]]; then
-      echo "Error: No PR number found"
-      exit 1
-    fi
-  else
-    echo "* PR_NUMBER manually defined to: $INPUT_PR_NUMBER"
-    set +e
-    PR_NUMBER=$(echo "$INPUT_PR_NUMBER" | grep -oE '[0-9]+')
-    set -e
-    if [[ -z "$PR_NUMBER" ]]; then
-      echo "Error: No PR number found"
-      exit 1
-    fi
-  fi
-  echo "Parsed value: $PR_NUMBER"
-  echo ""
-  ESCAPED_BRANCH=$(echo "$PR_NUMBER-$ESCAPED_BRANCH")
-fi
-
-if [[ -z "$INPUT_HOST" ]]; then
-  # Compute review-app host
-  if [[ -z "$INPUT_ROOT_DOMAIN" ]]; then
-    INPUT_HOST=$(echo "$ESCAPED_BRANCH")
-
-    if [[ -n "$INPUT_FQDN_PREFIX" ]]; then
-      INPUT_HOST=$(echo "$INPUT_FQDN_PREFIX$INPUT_HOST")
-    fi
-
-    # Limit to 64 chars max
-    INPUT_HOST="${INPUT_HOST:0:64}"
-
-    # Remove the trailing "-" character
-    if [[ $INPUT_HOST == *- ]]; then
-        INPUT_HOST="${INPUT_HOST%-}"
-    fi
-  else
-    INPUT_HOST=$(echo "$ESCAPED_BRANCH.$INPUT_ROOT_DOMAIN")
-
-    if [[ -n "$INPUT_FQDN_PREFIX" ]]; then
-      INPUT_HOST=$(echo "$INPUT_FQDN_PREFIX$INPUT_HOST")
-    fi
-
-    # Limit to 64 chars max
-    if [ ${#INPUT_HOST} -gt 64 ]; then
-      INPUT_HOST=$(echo "${ESCAPED_BRANCH:0:$((${#ESCAPED_BRANCH} - $((${#INPUT_HOST} - 64))))}.$INPUT_ROOT_DOMAIN")
-    fi
-
-    # Remove dash in middle of the host
-    if [[ $INPUT_HOST == *-.$INPUT_ROOT_DOMAIN ]]; then
-        INPUT_HOST=$(echo $INPUT_HOST | sed "s/-\.$INPUT_ROOT_DOMAIN/\.$INPUT_ROOT_DOMAIN/")
-    fi
-  fi
-fi
-
-if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
-  echo "host=$INPUT_HOST" >> $GITHUB_OUTPUT
-fi
-
-if [[ -z "$INPUT_DATABASE_NAME" ]]; then
-  # Compute database name
-  INPUT_DATABASE_NAME=$(echo "$ESCAPED_BRANCH" | sed -e 's/[^a-z0-9_]/_/g' | tr -s '_')
-fi
-
-if [[ -n "$INPUT_DATABASE_NAME_PREFIX" ]]; then
-  INPUT_DATABASE_NAME=$(echo "$INPUT_DATABASE_NAME_PREFIX$INPUT_DATABASE_NAME")
-fi
-
-# Limit to 63 chars max
-INPUT_DATABASE_NAME="${INPUT_DATABASE_NAME:0:63}"
-
-if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
-  echo "database_name=$INPUT_DATABASE_NAME" >> $GITHUB_OUTPUT
-fi
-
 AUTH_HEADER="Authorization: Bearer $INPUT_FORGE_API_TOKEN"
 ACCEPT_HEADER="Accept: application/vnd.api+json"
-
 API_BASE="https://forge.laravel.com/api/orgs/$INPUT_FORGE_ORGANIZATION/servers/$INPUT_FORGE_SERVER_ID"
 
-echo '* Get Forge server sites'
-API_URL="$API_BASE/sites?filter%5Bname%5D=$INPUT_HOST"
-JSON_RESPONSE=$(
-  curl -s -H "$AUTH_HEADER" \
-    -H "$ACCEPT_HEADER" \
-    "$API_URL"
-)
-echo "$JSON_RESPONSE" > sites.json
+# Delete a Forge site by exact host name, if it exists.
+# Sets SITE_DELETED to 'true'/'false'.
+delete_site() {
+  HOST="$1"
 
-# Check if review-app site exists (filter[name] may be a partial match, so confirm the exact name)
-SITE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$INPUT_HOST"'") // empty' sites.json)
-if [[ ! -z "$SITE_DATA" ]]; then
+  API_URL="$API_BASE/sites?filter%5Bname%5D=$HOST"
+  JSON_RESPONSE=$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" "$API_URL")
+  echo "$JSON_RESPONSE" > sites.json
+
+  # Check if review-app site exists (filter[name] may be a partial match, so confirm the exact name)
+  SITE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$HOST"'") // empty' sites.json)
+  if [[ -z "$SITE_DATA" ]]; then
+    echo "Site $HOST not found"
+    SITE_DELETED='false'
+    return
+  fi
+
   echo "$SITE_DATA" > site.json
   SITE_ID=$(jq -r '.id' site.json)
   echo "A site (ID $SITE_ID) name match the host"
-  RA_FOUND='true'
-else
-  echo "Site $INPUT_HOST not found"
-  RA_FOUND='false'
-fi
 
-if [[ $RA_FOUND == 'true' ]]; then
   echo ""
   echo "* Delete review-app site"
 
   API_URL="$API_BASE/sites/$SITE_ID"
-
   HTTP_STATUS=$(
     curl -s -o response.json -w "%{http_code}" \
       -X DELETE \
@@ -137,47 +37,46 @@ if [[ $RA_FOUND == 'true' ]]; then
       -H "$ACCEPT_HEADER" \
       "$API_URL"
   )
-
   JSON_RESPONSE=$(cat response.json)
 
   if [[ $HTTP_STATUS -eq 202 ]]; then
     echo "Site (ID $SITE_ID) deleted successfully"
+    SITE_DELETED='true'
   else
     echo "Failed to delete site (ID $SITE_ID). HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
     exit 1
   fi
-fi
+}
 
-echo ""
-echo '* Get Forge server databases'
-API_URL="$API_BASE/database/schemas?filter%5Bname%5D=$INPUT_DATABASE_NAME"
-JSON_RESPONSE=$(
-  curl -s -H "$AUTH_HEADER" \
-    -H "$ACCEPT_HEADER" \
-    "$API_URL"
-)
-echo "$JSON_RESPONSE" > databases.json
+# Delete a Forge database schema by exact name, if it exists.
+# Sets DATABASE_DELETED to 'true'/'false'.
+delete_database() {
+  DB_NAME="$1"
 
-# Check if review-app database exists (filter[name] may be a partial match, so confirm the exact name)
-DATABASE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$INPUT_DATABASE_NAME"'") // empty' databases.json)
-if [[ ! -z "$DATABASE_DATA" ]]; then
+  echo ""
+  echo '* Get Forge server databases'
+  API_URL="$API_BASE/database/schemas?filter%5Bname%5D=$DB_NAME"
+  JSON_RESPONSE=$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" "$API_URL")
+  echo "$JSON_RESPONSE" > databases.json
+
+  # Check if review-app database exists (filter[name] may be a partial match, so confirm the exact name)
+  DATABASE_DATA=$(jq -r '.data[] | select(.attributes.name == "'"$DB_NAME"'") // empty' databases.json)
+  if [[ -z "$DATABASE_DATA" ]]; then
+    echo "Database $DB_NAME not found"
+    DATABASE_DELETED='false'
+    return
+  fi
+
   echo "$DATABASE_DATA" > database.json
   DATABASE_ID=$(jq -r '.id' database.json)
-  echo "A database (ID $DATABASE_ID, NAME $INPUT_DATABASE_NAME) name match the host"
-  DATABASE_FOUND='true'
-else
-  echo "Database $INPUT_DATABASE_NAME not found"
-  DATABASE_FOUND='false'
-fi
+  echo "A database (ID $DATABASE_ID, NAME $DB_NAME) name match the host"
 
-if [[ $DATABASE_FOUND == 'true' ]]; then
   echo ""
   echo "* Delete review-app database"
 
   API_URL="$API_BASE/database/schemas/$DATABASE_ID"
-
   HTTP_STATUS=$(
     curl -s -o response.json -w "%{http_code}" \
       -X DELETE \
@@ -185,15 +84,296 @@ if [[ $DATABASE_FOUND == 'true' ]]; then
       -H "$ACCEPT_HEADER" \
       "$API_URL"
   )
-
   JSON_RESPONSE=$(cat response.json)
 
   if [[ $HTTP_STATUS -eq 202 ]]; then
-    echo "Database (ID $DATABASE_ID, NAME $INPUT_DATABASE_NAME) deleted successfully"
+    echo "Database (ID $DATABASE_ID, NAME $DB_NAME) deleted successfully"
+    DATABASE_DELETED='true'
   else
-    echo "Failed to delete database (ID $DATABASE_ID, NAME $INPUT_DATABASE_NAME). HTTP status code: $HTTP_STATUS"
+    echo "Failed to delete database (ID $DATABASE_ID, NAME $DB_NAME). HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
     exit 1
   fi
+}
+
+run_classic_mode() {
+  # Prepare vars and default values
+
+  if [[ -z "$INPUT_BRANCH" ]]; then
+    INPUT_BRANCH=$GITHUB_HEAD_REF
+  fi
+
+  ESCAPED_BRANCH=$(echo "$INPUT_BRANCH" | sed -e 's/[^a-z0-9-]/-/g' | tr -s '-')
+
+  # Remove the trailing "-" character
+  if [[ $ESCAPED_BRANCH == *- ]]; then
+      ESCAPED_BRANCH="${ESCAPED_BRANCH%-}"
+  fi
+
+  if [[ -z "$INPUT_PREFIX_WITH_PR_NUMBER" ]]; then
+    INPUT_PREFIX_WITH_PR_NUMBER='true'
+  fi
+
+  if [[ $INPUT_PREFIX_WITH_PR_NUMBER == 'true' ]]; then
+    if [[ -z "$INPUT_PR_NUMBER" ]]; then
+      echo "* PR_NUMBER extraction from GITHUB_REF_NAME value: $GITHUB_REF_NAME"
+      set +e
+      PR_NUMBER=$(echo "$GITHUB_REF_NAME" | grep -oE '[0-9]+')
+      set -e
+      if [[ -z "$PR_NUMBER" ]]; then
+        echo "Error: No PR number found"
+        exit 1
+      fi
+    else
+      echo "* PR_NUMBER manually defined to: $INPUT_PR_NUMBER"
+      set +e
+      PR_NUMBER=$(echo "$INPUT_PR_NUMBER" | grep -oE '[0-9]+')
+      set -e
+      if [[ -z "$PR_NUMBER" ]]; then
+        echo "Error: No PR number found"
+        exit 1
+      fi
+    fi
+    echo "Parsed value: $PR_NUMBER"
+    echo ""
+    ESCAPED_BRANCH=$(echo "$PR_NUMBER-$ESCAPED_BRANCH")
+  fi
+
+  if [[ -z "$INPUT_HOST" ]]; then
+    # Compute review-app host
+    if [[ -z "$INPUT_ROOT_DOMAIN" ]]; then
+      INPUT_HOST=$(echo "$ESCAPED_BRANCH")
+
+      if [[ -n "$INPUT_FQDN_PREFIX" ]]; then
+        INPUT_HOST=$(echo "$INPUT_FQDN_PREFIX$INPUT_HOST")
+      fi
+
+      # Limit to 64 chars max
+      INPUT_HOST="${INPUT_HOST:0:64}"
+
+      # Remove the trailing "-" character
+      if [[ $INPUT_HOST == *- ]]; then
+          INPUT_HOST="${INPUT_HOST%-}"
+      fi
+    else
+      INPUT_HOST=$(echo "$ESCAPED_BRANCH.$INPUT_ROOT_DOMAIN")
+
+      if [[ -n "$INPUT_FQDN_PREFIX" ]]; then
+        INPUT_HOST=$(echo "$INPUT_FQDN_PREFIX$INPUT_HOST")
+      fi
+
+      # Limit to 64 chars max
+      if [ ${#INPUT_HOST} -gt 64 ]; then
+        INPUT_HOST=$(echo "${ESCAPED_BRANCH:0:$((${#ESCAPED_BRANCH} - $((${#INPUT_HOST} - 64))))}.$INPUT_ROOT_DOMAIN")
+      fi
+
+      # Remove dash in middle of the host
+      if [[ $INPUT_HOST == *-.$INPUT_ROOT_DOMAIN ]]; then
+          INPUT_HOST=$(echo $INPUT_HOST | sed "s/-\.$INPUT_ROOT_DOMAIN/\.$INPUT_ROOT_DOMAIN/")
+      fi
+    fi
+  fi
+
+  if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
+    echo "host=$INPUT_HOST" >> $GITHUB_OUTPUT
+  fi
+
+  if [[ -z "$INPUT_DATABASE_NAME" ]]; then
+    # Compute database name
+    INPUT_DATABASE_NAME=$(echo "$ESCAPED_BRANCH" | sed -e 's/[^a-z0-9_]/_/g' | tr -s '_')
+  fi
+
+  if [[ -n "$INPUT_DATABASE_NAME_PREFIX" ]]; then
+    INPUT_DATABASE_NAME=$(echo "$INPUT_DATABASE_NAME_PREFIX$INPUT_DATABASE_NAME")
+  fi
+
+  # Limit to 63 chars max
+  INPUT_DATABASE_NAME="${INPUT_DATABASE_NAME:0:63}"
+
+  if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
+    echo "database_name=$INPUT_DATABASE_NAME" >> $GITHUB_OUTPUT
+  fi
+
+  echo '* Get Forge server sites'
+  delete_site "$INPUT_HOST"
+
+  echo ""
+  delete_database "$INPUT_DATABASE_NAME"
+}
+
+# List every site on the Forge server, following JSON:API pagination (links.next).
+# Writes the full JSON array of site objects to $1.
+list_all_sites() {
+  OUTPUT_FILE="$1"
+  API_URL="$API_BASE/sites"
+  echo '[]' > "$OUTPUT_FILE"
+
+  while [[ -n "$API_URL" && "$API_URL" != "null" ]]; do
+    JSON_RESPONSE=$(curl -s -H "$AUTH_HEADER" -H "$ACCEPT_HEADER" "$API_URL")
+    echo "$JSON_RESPONSE" | jq '.data' > page.json
+    jq -s '.[0] + .[1]' "$OUTPUT_FILE" page.json > merged.json
+    mv merged.json "$OUTPUT_FILE"
+    API_URL=$(echo "$JSON_RESPONSE" | jq -r '.links.next // empty')
+  done
+}
+
+# Derive the review-app database name from its host the same way the classic
+# mode would have generated it from the branch name, since the branch name
+# itself is not available in discovery mode.
+# NB: this does not account for a custom fqdn_prefix, which is not
+# recoverable from the host alone.
+derive_database_name_from_host() {
+  HOST="$1"
+  SEGMENT="$HOST"
+  if [[ -n "$INPUT_ROOT_DOMAIN" && "$HOST" == *".$INPUT_ROOT_DOMAIN" ]]; then
+    SEGMENT="${HOST%.$INPUT_ROOT_DOMAIN}"
+  fi
+  DB_NAME=$(echo "$SEGMENT" | sed -e 's/[^a-z0-9_]/_/g' | tr -s '_')
+  if [[ -n "$INPUT_DATABASE_NAME_PREFIX" ]]; then
+    DB_NAME=$(echo "$INPUT_DATABASE_NAME_PREFIX$DB_NAME")
+  fi
+  echo "${DB_NAME:0:63}"
+}
+
+# Check the state of a GitHub PR.
+# Echoes one of: open | closed | not_found | unknown (API error/rate-limit: treat as "don't touch").
+check_pr_state() {
+  PR_NUMBER="$1"
+
+  GH_URL="https://api.github.com/repos/$EFFECTIVE_REPOSITORY/pulls/$PR_NUMBER"
+  HTTP_STATUS=$(
+    curl -s -o pr_response.json -w "%{http_code}" \
+      -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "$GH_URL"
+  )
+
+  if [[ $HTTP_STATUS -eq 200 ]]; then
+    STATE=$(jq -r '.state // empty' pr_response.json)
+    if [[ "$STATE" == "open" ]]; then
+      echo "open"
+    else
+      echo "closed"
+    fi
+  elif [[ $HTTP_STATUS -eq 404 ]]; then
+    echo "not_found"
+  else
+    echo "unknown"
+  fi
+}
+
+run_cleanup_orphans_mode() {
+  if [[ -z "$INPUT_GITHUB_TOKEN" ]]; then
+    echo "Error: 'github_token' input is required when 'cleanup_orphans' is true"
+    exit 1
+  fi
+
+  EFFECTIVE_REPOSITORY="$INPUT_REPOSITORY"
+  if [[ -z "$EFFECTIVE_REPOSITORY" ]]; then
+    EFFECTIVE_REPOSITORY="$GITHUB_REPOSITORY"
+  fi
+  if [[ -z "$EFFECTIVE_REPOSITORY" ]]; then
+    echo "Error: 'repository' input is required when 'cleanup_orphans' is true (and GITHUB_REPOSITORY is not set)"
+    exit 1
+  fi
+
+  EFFECTIVE_HOST_PATTERN="$INPUT_HOST_PATTERN"
+  if [[ -z "$EFFECTIVE_HOST_PATTERN" ]]; then
+    if [[ -z "$INPUT_ROOT_DOMAIN" ]]; then
+      echo "Error: either 'host_pattern' or 'root_domain' input is required when 'cleanup_orphans' is true"
+      exit 1
+    fi
+    ESCAPED_ROOT_DOMAIN=$(echo "$INPUT_ROOT_DOMAIN" | sed -e 's/\./\\./g')
+    EFFECTIVE_HOST_PATTERN="^[0-9]+-.*\.${ESCAPED_ROOT_DOMAIN}\$"
+  fi
+
+  echo "* Repository: $EFFECTIVE_REPOSITORY"
+  echo "* Host pattern: $EFFECTIVE_HOST_PATTERN"
+  echo "* Dry run: ${INPUT_DRY_RUN:-false}"
+  echo ""
+
+  echo '* Get Forge server sites (paginated)'
+  list_all_sites all_sites.json
+  TOTAL_SITES=$(jq 'length' all_sites.json)
+  echo "Found $TOTAL_SITES site(s) on the server"
+
+  echo ""
+  echo '* Filter sites matching host_pattern and extract PR number'
+  jq --arg pat "$EFFECTIVE_HOST_PATTERN" '
+    [.[] | select(.attributes.name | test($pat))
+         | {id: .id, host: .attributes.name}]
+  ' all_sites.json > matched_sites.json
+
+  # Extract the PR number (leading digits) from each matched host, drop
+  # non-matching entries, then dedup by PR number (keep first occurrence).
+  jq '
+    [.[] | (.host | capture("^(?<pr>[0-9]+)-").pr) as $pr | . + {pr: $pr}]
+    | unique_by(.pr)
+  ' matched_sites.json > candidates.json
+
+  CANDIDATE_COUNT=$(jq 'length' candidates.json)
+  echo "Found $CANDIDATE_COUNT candidate review-app(s) after filtering/dedup"
+
+  ORPHANS_FOUND=0
+  ORPHANS_DELETED=0
+  echo '[]' > orphans.json
+
+  for i in $(seq 0 $((CANDIDATE_COUNT - 1))); do
+    [[ $CANDIDATE_COUNT -eq 0 ]] && break
+
+    CANDIDATE=$(jq -c ".[$i]" candidates.json)
+    CANDIDATE_PR=$(echo "$CANDIDATE" | jq -r '.pr')
+    CANDIDATE_HOST=$(echo "$CANDIDATE" | jq -r '.host')
+
+    echo ""
+    echo "* Checking PR #$CANDIDATE_PR (site: $CANDIDATE_HOST)"
+    PR_STATE=$(check_pr_state "$CANDIDATE_PR")
+
+    if [[ "$PR_STATE" == "open" ]]; then
+      echo "PR #$CANDIDATE_PR is open, skipping (not orphaned)"
+      continue
+    fi
+
+    if [[ "$PR_STATE" == "unknown" ]]; then
+      echo "Warning: could not reliably determine PR #$CANDIDATE_PR state (API error/rate-limit). Skipping site to be safe, it will be re-checked on the next run."
+      continue
+    fi
+
+    # PR_STATE is "closed" or "not_found": confirmed orphan
+    echo "PR #$CANDIDATE_PR is $PR_STATE, site $CANDIDATE_HOST is orphaned"
+    ORPHANS_FOUND=$((ORPHANS_FOUND + 1))
+    DELETED='false'
+
+    if [[ "${INPUT_DRY_RUN:-false}" == 'true' ]]; then
+      echo "[dry_run] Would delete site $CANDIDATE_HOST (and its database)"
+    else
+      delete_site "$CANDIDATE_HOST"
+      DB_NAME=$(derive_database_name_from_host "$CANDIDATE_HOST")
+      delete_database "$DB_NAME"
+      DELETED='true'
+      ORPHANS_DELETED=$((ORPHANS_DELETED + 1))
+    fi
+
+    jq --arg pr "$CANDIDATE_PR" --arg host "$CANDIDATE_HOST" --argjson deleted "$DELETED" \
+      '. + [{pr: $pr, host: $host, deleted: $deleted}]' orphans.json > orphans.json.tmp
+    mv orphans.json.tmp orphans.json
+  done
+
+  echo ""
+  echo "* Summary: $ORPHANS_FOUND orphan(s) found, $ORPHANS_DELETED deleted"
+
+  if [[ -n "$GITHUB_ACTIONS" && "$GITHUB_ACTIONS" == "true" ]]; then
+    echo "host=" >> $GITHUB_OUTPUT
+    echo "database_name=" >> $GITHUB_OUTPUT
+    echo "orphans_found=$ORPHANS_FOUND" >> $GITHUB_OUTPUT
+    echo "orphans_deleted=$ORPHANS_DELETED" >> $GITHUB_OUTPUT
+    echo "orphans_json=$(jq -c '.' orphans.json)" >> $GITHUB_OUTPUT
+  fi
+}
+
+if [[ "$INPUT_CLEANUP_ORPHANS" == 'true' ]]; then
+  run_cleanup_orphans_mode
+else
+  run_classic_mode
 fi


### PR DESCRIPTION
## Summary
- Adds a new `cleanup_orphans` input (default `false`) that switches the action from targeted single-site deletion to server-wide discovery: list every Forge site, filter by `host_pattern`, check each associated PR via the GitHub API, and delete sites whose PR is closed/merged/deleted.
- Safety: a PR check that errors or is rate-limited is treated as "unknown" and the site is **skipped, never deleted** — it gets re-checked on the next scheduled run.
- New outputs: `orphans_found`, `orphans_deleted`, `orphans_json`.
- Purely additive: default mode (`cleanup_orphans` absent/`false`) runs the exact same code path as before (`run_classic_mode`), verified both structurally (diffed against `main`) and by re-running it end-to-end against a mocked Forge API — same outputs, same log sequence.
- Bumps the Docker image tag referenced in `action.yml` to `v2.1.0` (not yet built/published — needs a tag push after merge to trigger `build.yml`).

## Test plan
- [x] `bash -n entrypoint.sh` passes
- [x] Classic mode re-run against a mocked Forge API produces identical `host`/`database_name` outputs and deletion sequence as before the change
- [x] Orphan mode tested against a mocked Forge + GitHub API: open PR skipped, closed/merged PR deleted, 404 (deleted PR) deleted, GitHub API error (403 rate-limit) skipped without deletion
- [x] `dry_run: true` produces `orphans_deleted: 0` and performs no actual deletion
- [ ] Push `v2.1.0` tag after merge to build/publish the Docker image before any consumer sets `cleanup_orphans: true`
- [ ] Real dry-run against an actual Forge server before disabling dry_run in any consumer workflow